### PR TITLE
include inputs of item descriptions and unities

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,19 +22,7 @@
     <h1>Sua Lista de Compras</h1>
     <div class="container mt-3 mb-3 p-3" id="inputField">
       <div class="row">
-        <div class="col-lg-8 d-inline-flex mb-3 mt-3 ps-4">
-          <div class="input-group input-group-lg">
-            <span class="input-group-text" id="input-item-label">Item</span>
-            <input
-              type="text"
-              class="form-control"
-              name="inputItem"
-              id="inputItem"
-              placeholder="Insira um item a sua lista"
-            />
-          </div>
-        </div>
-        <div class="col-lg-4 d-inline-flex justify-content-around mb-3 mt-3 ps-4" id="QttyAndBtn">
+        <div class="col-xl-4 d-inline-flex justify-content-around align-items-center mb-3 mt-3 ps-4" id="QttyAndUnity">
           <div class="input-group input-group-lg flex-nowrap">
             <span class="input-group-text" id="input-qtty-label">Qtd.</span>
             <input
@@ -46,16 +34,50 @@
               size="4"
               value="1"
             />
+            <div class="form-floating">
+              <select
+                class="form-select form-select-lg px-3"
+                id="selectUnity"
+                aria-label="Unidades"
+              >
+                <option selected value="un.">Unidade</option>
+                <option value="kg">Kilograma</option>
+                <option value="g">grama</option>
+                <option value="Duz">Dúzia</option>
+                <option value="1/2 Duz">Meia dúzia</option>
+              </select>
+              <label for="floatingSelect">Unidades</label>
+            </div>
           </div>
-          <button
-            type="button"
-            class="btn btn-success btn-sm ms-2"
-            id="btnAdd"
-            onclick="addElementToList('listTable')"
-          >
-            <span class="bi bi-bag-plus-fill" id="addIcon"></span>
-            Adicionar
-          </button>
+        </div>
+        <div class="col-xl-8 d-flex flex-column mb-3 mt-3 ps-4">
+          <div class="input-group input-group-lg">
+            <input
+              type="text"
+              class="form-control"
+              name="inputItem"
+              id="inputItem"
+              placeholder="Item"
+            />
+            <button
+              type="button"
+              class="btn btn-success btn-sm"
+              id="btnAdd"
+              onclick="addElement('listTable')"
+            >
+              <span class="bi bi-bag-plus-fill" id="addIcon"></span>
+              Adicionar
+            </button>
+          </div>
+          <div class="input-group input-group-sm ms-2 mt-1">
+            <input
+              type="text"
+              class="form-control"
+              name="inputItemDescription"
+              id="inputItemDescription"
+              placeholder="Descrição do Item (Ex: Embalagem de 2l; Pacote 5kg; pack c/ 12...)"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -1,33 +1,32 @@
 const addButton = document.getElementById('btnAdd');
+const arrayOfItems = [];
 addButton.disabled = true;
 const qtty = document.getElementById('inputQtty');
 qtty.value = '1';
-document.getElementById('inputItem').addEventListener('change', validatEmptyInputs);
-document.getElementById('inputItem').addEventListener('change', validateDuplicatedItem);
-
 function validatEmptyInputs() {
   const item = document.getElementById('inputItem').value;
   addButton.disabled = item.trim() === '';
 }
+document.getElementById('inputItem').addEventListener('change', validatEmptyInputs);
 
 function validateDuplicatedItem() {
-  const table = document.getElementById('listTable');
-  const numOfRows = table.rows.length;
-  const item = document.getElementById('inputItem').value;
-  for (let i = 1; i < numOfRows; i++) {
-    const cellText = table.rows[i].cells.item(0).innerHTML;
-    if (cellText.trim() == item.trim()) {
-      addButton.disabled = true;
-      break;
-    }
-  }
+  const newItem = document.getElementById('inputItem').value.trim();
+  addButton.disabled = arrayOfItems.some(registeredItem => registeredItem.item === newItem )
 }
+document.getElementById('inputItem').addEventListener('change', validateDuplicatedItem);
 
-function addElementToList(tableReference) {
+function addElement(tableReference) {
+  const newProduct = {
+    item: document.getElementById('inputItem').value.trim(),
+    itemDescription: document.getElementById('inputItemDescription').value.trim(),
+    quantity: document.getElementById('inputQtty').value,
+    unity: document.getElementById('selectUnity').value,
+  };
+  arrayOfItems.push(newProduct);
   const newRowIndex = insertNewRow(tableReference).rowIndex;
   const currentRowRef = document.getElementById(tableReference).rows[newRowIndex];
-  writeItemOnTable(currentRowRef);
-  writeQttyOnTable(currentRowRef);
+  writeItemOnTable(currentRowRef, newProduct.item, newProduct.itemDescription);
+  writeQttyOnTable(currentRowRef, newProduct.quantity, newProduct.unity);
   createDeltBttn(currentRowRef);
   createEditBttn(currentRowRef);
   addButton.disabled = true;
@@ -38,20 +37,20 @@ function insertNewRow(tableID) {
   const newRow = table.tBodies[0].insertRow(-1);
   return newRow;
 }
-function writeItemOnTable(rowReference) {
+function writeItemOnTable(rowReference, itemName, descripionOfItem) {
   const cellOfitens = rowReference.insertCell(0);
-  const itemText = document.getElementById('inputItem').value;
   cellOfitens.id = 'intensCell';
-  cellOfitens.innerHTML = itemText;
+  cellOfitens.innerHTML = `<p>${itemName} </p> <p class="itemsDescription" > ${descripionOfItem} </p> `;
   document.getElementById('inputItem').value = '';
+  document.getElementById('inputItemDescription').value = '';
 }
-function writeQttyOnTable(rowReference) {
+function writeQttyOnTable(rowReference, qtty, unitySymbol) {
   const cellOfQtty = rowReference.insertCell();
-  const qttyText = document.getElementById('inputQtty').value;
   cellOfQtty.className = 'align-middle';
   cellOfQtty.id = 'qttyCells';
-  cellOfQtty.innerHTML = qttyText;
+  cellOfQtty.innerHTML = `${qtty} ${unitySymbol}`;
   document.getElementById('inputQtty').value = '1';
+  document.getElementById('selectUnity').value = 'un.';
 }
 function createDeltBttn(rowReference) {
   const cellDelete = rowReference.insertCell();
@@ -66,13 +65,15 @@ function createDeltBttn(rowReference) {
   delBtn.className = 'btn btn-danger d-flex align-items-center justify-content-center';
   delBtn.id = 'delBtn';
   delBtn.onclick = function () {
-    deleteRow(this);
+    removeItem(this);
   };
   cellDelete.appendChild(delBtn);
 }
-function deleteRow(rowToBeDeleted) {
-  const indexOfRow = rowToBeDeleted.parentNode.parentNode.rowIndex;
+
+function removeItem(deleteBtnReference) {
+  const indexOfRow = deleteBtnReference.parentNode.parentNode.rowIndex;
   document.getElementById('listTable').deleteRow(indexOfRow);
+  arrayOfItems.splice(indexOfRow - 1, 1);
 }
 function createEditBttn(rowReference) {
   const cellEdit = rowReference.insertCell();

--- a/style.css
+++ b/style.css
@@ -25,12 +25,28 @@ div#inputField:hover {
   background-color: #f45720;
   box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.6);
 }
+#inputItemDescription {
+  font-size: smaller;
+  height: 3.5em;
+  max-width: 85%;
+  border-radius: 0px;
+}
+.itemsDescription {
+  margin-top: -1.5em;
+  margin-bottom: -1.5em;
+  font-size: 0.75em;
+  font-style: italic;
+  text-indent: 1em;
+}
 
 .btn:focus {
   outline: none;
   box-shadow: none;
 }
 #btnAdd {
+  width: min-content;
+  font-size:smaller;
+  text-align: center;
   opacity: 0.7;
   transition: 0.5s;
 }
@@ -43,8 +59,18 @@ div#inputField:hover {
 }
 
 #inputQtty {
-  max-width: 5em;
-  min-width: 5em;
+  max-width: 6em;
+  min-width: 6em;
+  border-right: 0px;
+}
+#selectUnity {
+  max-width: 9em;
+  min-width: 9em;
+  height: 5.1em;
+  font-size: smaller;
+  border-left: 0px;
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
 }
 
 div#listArea {
@@ -87,7 +113,11 @@ table#listTable th#headCellItem {
 tbody {
   font-size: 15pt;
 }
-
+table#listTable tr {
+  line-height: 1.5rem;
+  min-height: 3rem;
+  height: 3rem;
+}
 #qttyCells {
   text-align: center;
   width: 15%;


### PR DESCRIPTION
# Works on this branch.
 - Include select input of unities (Kg, g, dúzia, meia-dúzia,unidade)
 - Include input text for items description (Ex: Pacote 5kg, pack c/12, etc.)
 - add unities symbols to quantity text
 - add item description text in the item table cell
 ## Commit "include inputs of item descriptions and unities":
- Include and stylize the input selection with some usual unities;
- Include  and stylize an input text for items descriptions;
- Layout changes on the input field (orange container) to better accommodate the new elements.
## Commit "implement and use array containing items objects":
- create an array containing objects that represents the items with the properties: (item; itemDescription; quantity; unity);
- Use this array to determine if a new user entry was already add to list ( function: valiadateDuplicateItems)
This array is necessary to validate duplicated items, since the approach of "read" the table text does not work after inserting the item descriptions. 
Some changes was made in the function that delete items. The first one was the parameter name (previously rowToBeDeleted), because which actually is passed as a parameter is a reference to the clicked deleteButton. The second chance is that this function also delete the item in the arrayOfItems.